### PR TITLE
[FEATURE] Limit responsibility up to a specified level

### DIFF
--- a/Classes/Log/LogLevel.php
+++ b/Classes/Log/LogLevel.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "mteu/typo3-stream-writer".
+ *
+ * Copyright (C) 2024 Martin Adler <mteu@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace mteu\StreamWriter\Log;
+
+enum LogLevel: string
+{
+    case ALERT     = 'alert';
+    case CRITICAL  = 'critical';
+    case DEBUG     = 'debug';
+    case EMERGENCY = 'emergency';
+    case ERROR     = 'error';
+    case INFO      = 'info';
+    case NOTICE    = 'notice';
+    case WARNING   = 'warning';
+
+    public function priority(): int
+    {
+        return match ($this) {
+            self::EMERGENCY => 8,
+            self::ALERT => 7,
+            self::CRITICAL => 6,
+            self::ERROR => 5,
+            self::WARNING => 4,
+            self::NOTICE => 3,
+            self::INFO => 2,
+            self::DEBUG => 1,
+        };
+    }
+}

--- a/Classes/Log/LogLevel.php
+++ b/Classes/Log/LogLevel.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 
 namespace mteu\StreamWriter\Log;
 
+/**
+ * @codeCoverageIgnore
+ */
 enum LogLevel: string
 {
     case ALERT     = 'alert';

--- a/Classes/Log/Writer/StreamWriter.php
+++ b/Classes/Log/Writer/StreamWriter.php
@@ -203,11 +203,8 @@ final class StreamWriter extends AbstractWriter
 
     private function levelIsWithinBounds(LogRecord $record): bool
     {
-        $logLevel = LogLevel::tryFrom($record->getLevel());
+        $logLevelPriority = LogLevel::tryFrom($record->getLevel())?->priority();
 
-        return
-            $logLevel === null ||
-            $logLevel->priority() > $this->maxLevel->priority()
-        ;
+        return $logLevelPriority <= $this->maxLevel->priority();
     }
 }

--- a/Documentation/writer-configuration.md
+++ b/Documentation/writer-configuration.md
@@ -1,0 +1,28 @@
+# LogWriter Configuration
+
+## Options
+The TYPO3 Stream Writer currently supports following options:
+
+| Option             | Required | Value                                                                                                                                       | Description                                                                                                                                                                                            |
+|--------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `outputStream`     | required | [`StandardStream::Err`](../Classes/Log/Config/StandardStream.php) or <br/>[`StandardStream::Out`](../Classes/Log/Config/StandardStream.php) | Direct your stream output either to `php://stdout` or `php://sterr`                                                                                                                                    |
+| `ignoreComponents` | optional | Array of classes to be excluded from logging via this LogWriter                                                                             | Please note that classes are currently repesented by the full qualified class name syntax the TYPO3 Logging Framework uses.<br/> _This is likely to change to accept actual class strings there, too_. |
+| `maxLevel`         | optional | `Psr\Log\LogLevel`                                                                                                                          | Although, you may go with their respective `string` representations, it is recommended to stick to `Psr\Log\LogLevel` for compatibility.                                                               |
+|                    |          |                                                                                                                                             |                                                                                                                                                                                                        |
+
+## Example
+
+```php
+$GLOBALS['TYPO3_CONF_VARS']['LOG']['writerConfiguration'] = [
+    \Psr\Log\LogLevel::DEBUG => [
+        StreamWriter::class => [
+            'outputStream' => StandardStream::Out,
+            'ignoreComponents' => [
+                'TYPO3.CMS.Core.Authentication.BackendUserAuthentication',
+                'TYPO3.CMS.Frontend.Authentication.FrontendUserAuthentication',
+            ],
+            'maxLevel' => Psr\Log\LogLevel::WARNING,
+        ],
+    ],
+];
+```

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 [![TYPO3 12](https://img.shields.io/badge/TYPO3-12-orange.svg)](https://get.typo3.org/version/12)
 [![TYPO3 13](https://img.shields.io/badge/TYPO3-13-orange.svg)](https://get.typo3.org/version/13)
-
 [![CGL](https://github.com/mteu/typo3-stream-writer/actions/workflows/cgl.yaml/badge.svg)](https://github.com/mteu/typo3-stream-writer/actions/workflows/cgl.yaml)
 [![Tests](https://github.com/mteu/typo3-stream-writer/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/mteu/typo3-stream-writer/actions/workflows/tests.yaml)
-[![codecov](https://codecov.io/gh/mteu/typo3-stream-writer/graph/badge.svg?token=XIx5ikuAYF)](https://codecov.io/gh/mteu/typo3-stream-writer)
 [![Coverage Status](https://coveralls.io/repos/github/mteu/typo3-stream-writer/badge.svg)](https://coveralls.io/github/mteu/typo3-stream-writer)
+[![Maintainability](https://api.codeclimate.com/v1/badges/edd606b0c4de053a2762/maintainability)](https://codeclimate.com/github/mteu/typo3-stream-writer/maintainability)
 
-# TYPO3 Stream Writer
+# TYPO3 Stream Writer 📜
 </div>
 
 This TYPO3 CMS extensions adds a custom `LogWriter` to the TYPO3 Logging Framework allowing the CMS to log messages to

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['writerConfiguration'] = [
                 'TYPO3.CMS.Core.Authentication.BackendUserAuthentication',
                 'TYPO3.CMS.Frontend.Authentication.FrontendUserAuthentication',
             ],
+            'maxLevel' => Psr\Log\LogLevel::WARNING,
         ],
     ],
 ];
 ```
+> 💡 Learn more about the LogWriter configuration in [`WriterConfiguration`](Documentation/writer-configuration.md).
+
 ## ⭐ License
 This project is licensed under [GNU General Public License 3.0 (or later)](LICENSE).


### PR DESCRIPTION
This PR adds a new LogWriter option `maxLevel` to control up to which `LogLevel` the LogWriter feels responsbile.

```php
$GLOBALS['TYPO3_CONF_VARS']['LOG']['writerConfiguration'] = [
     \Psr\Log\LogLevel::ERROR => [
        StreamWriter::class => [
            'outputStream' => StandardStream::Error,
        ],
    ],
    \Psr\Log\LogLevel::DEBUG => [
        StreamWriter::class => [
            'outputStream' => StandardStream::Out,
            'maxLevel' => Psr\Log\LogLevel::WARNING,
        ],
    ],
];
```