### PR TITLE
[BUGFIX] Fix typo in copyright docblock

### DIFF
--- a/Classes/Config/StandardStream.php
+++ b/Classes/Config/StandardStream.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extensions "mteu/typo3-stream-writer".
+ * This file is part of the TYPO3 CMS extension "mteu/typo3-stream-writer".
  *
  * Copyright (C) 2024 Martin Adler <mteu@mailbox.org>
  *

--- a/Classes/Exception/Exception.php
+++ b/Classes/Exception/Exception.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extensions "mteu/typo3-stream-writer".
+ * This file is part of the TYPO3 CMS extension "mteu/typo3-stream-writer".
  *
  * Copyright (C) 2024 Martin Adler <mteu@mailbox.org>
  *

--- a/Classes/Exception/InvalidLogWriterConfigurationException.php
+++ b/Classes/Exception/InvalidLogWriterConfigurationException.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extensions "mteu/typo3-stream-writer".
+ * This file is part of the TYPO3 CMS extension "mteu/typo3-stream-writer".
  *
  * Copyright (C) 2024 Martin Adler <mteu@mailbox.org>
  *

--- a/Classes/Exception/InvalidLogWriterOptionException.php
+++ b/Classes/Exception/InvalidLogWriterOptionException.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extensions "mteu/typo3-stream-writer".
+ * This file is part of the TYPO3 CMS extension "mteu/typo3-stream-writer".
  *
  * Copyright (C) 2024 Martin Adler <mteu@mailbox.org>
  *

--- a/Classes/Writer/StreamWriter.php
+++ b/Classes/Writer/StreamWriter.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extensions "mteu/typo3-stream-writer".
+ * This file is part of the TYPO3 CMS extension "mteu/typo3-stream-writer".
  *
  * Copyright (C) 2024 Martin Adler <mteu@mailbox.org>
  *


### PR DESCRIPTION
There is currently only one extension. Thanks for spotting this tiny glitch, @eliashaeussler!