### PR TITLE
[BUGFIX] Use STDOUT/STDERR directly for standard streams instead of fopen in StreamWriter

### DIFF
--- a/Classes/Writer/StreamWriter.php
+++ b/Classes/Writer/StreamWriter.php
@@ -168,11 +168,10 @@ final class StreamWriter extends AbstractWriter
 
     private function writeToResource(Message $message): void
     {
-        $resource = fopen($this->outputStream->value, 'w');
-
-        if ($resource === false) {
-            throw new \RuntimeException('Unable to write to ' . $this->outputStream->value . '.', 1722331957);
-        }
+        $resource = match ($this->outputStream) {
+            StandardStream::Out => STDOUT,
+            StandardStream::Error => STDERR,
+        };
 
         $output = fwrite($resource, $message->print());
 


### PR DESCRIPTION
This PR updates the StreamWriter class to use PHP's built-in `STDOUT` and `STDERR` resources directly when writing to standard streams. Previously, the code used `fopen` for all output streams, including standard streams, which is unnecessary and may cause issues or inefficiencies.